### PR TITLE
Add crane image tagging as job in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  packages: write
 
 jobs:
   release:
@@ -23,6 +24,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
 
     steps:
       - name: Checkout
@@ -43,8 +47,54 @@ jobs:
           @semantic-release/changelog
           @semantic-release/git
           @semantic-release/github
+          @semantic-release/exec
 
       - name: Run semantic-release
+        id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: |
+          npx semantic-release 2>&1 | tee /tmp/sr-output.txt
+          if grep -q "Published release" /tmp/sr-output.txt; then
+            VERSION=$(grep "Published release" /tmp/sr-output.txt | grep -oP '\d+\.\d+\.\d+')
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            echo "new_release_version=${VERSION}" >> $GITHUB_OUTPUT
+          else
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
+          fi
+
+  crane-tag:
+    name: Tag image with release version
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Copy SHA image to release tag
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          module: github.com/stuttgart-things/dagger/crane@v0.91.0
+          call: >-
+            copy
+            --source ghcr.io/stuttgart-things/sthings-backstage:${{ github.event.workflow_run.head_sha || github.sha }}
+            --target ghcr.io/stuttgart-things/sthings-backstage:v${{ needs.release.outputs.new_release_version }}
+            --target-registry ghcr.io
+            --target-username env:REGISTRY_USERNAME
+            --target-password env:REGISTRY_PASSWORD
+            --source-registry ghcr.io
+            --source-username env:REGISTRY_USERNAME
+            --source-password env:REGISTRY_PASSWORD
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+        env:
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Image Tagged" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** \`ghcr.io/stuttgart-things/sthings-backstage:${{ github.event.workflow_run.head_sha || github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tagged:** \`ghcr.io/stuttgart-things/sthings-backstage:v${{ needs.release.outputs.new_release_version }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Moves crane image tagging into the release workflow as a dependent `crane-tag` job
- Captures semantic-release output to detect new version and pass it to the crane job
- Fixes: `crane-tag.yaml` standalone workflow never triggered because `GITHUB_TOKEN` events don't trigger other workflows

## Flow
```
Docker Build → Release workflow:
  job 1: semantic-release → outputs version
  job 2: crane copy ghcr.io:sha → ghcr.io:vX.Y.Z (only if new release)
```

## Test plan
- [ ] Merge and verify release + crane tagging run together
- [ ] Confirm `ghcr.io/stuttgart-things/sthings-backstage:v1.2.0` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)