### PR TITLE
feat: add on-demand stage-image workflow

### DIFF
--- a/.github/workflows/stage-image.yaml
+++ b/.github/workflows/stage-image.yaml
@@ -1,0 +1,53 @@
+---
+name: Stage Image (ttl.sh -> ghcr.io)
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Source commit SHA present on ttl.sh (defaults to current ref SHA)"
+        required: false
+        type: string
+      tag:
+        description: "Target tag on ghcr.io"
+        required: false
+        default: stage
+        type: string
+      platform:
+        description: "Image platform"
+        required: false
+        default: linux/amd64
+        type: string
+
+concurrency:
+  group: stage-image-${{ inputs.tag }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  resolve:
+    name: Resolve inputs
+    runs-on: ubuntu-latest
+    outputs:
+      source-image: ${{ steps.vars.outputs.source-image }}
+      target-image: ${{ steps.vars.outputs.target-image }}
+    steps:
+      - id: vars
+        run: |
+          SHA="${{ inputs.sha }}"
+          if [ -z "$SHA" ]; then
+            SHA="${{ github.sha }}"
+          fi
+          echo "source-image=ttl.sh/stuttgart-things-sthings-backstage:${SHA}" >> $GITHUB_OUTPUT
+          echo "target-image=ghcr.io/stuttgart-things/sthings-backstage:${{ inputs.tag }}" >> $GITHUB_OUTPUT
+
+  stage:
+    needs: resolve
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-stage-image.yaml@main
+    with:
+      source-image: ${{ needs.resolve.outputs.source-image }}
+      target-image: ${{ needs.resolve.outputs.target-image }}
+      target-registry: ghcr.io
+      platform: ${{ inputs.platform }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/stage-image.yaml` — a `workflow_dispatch` workflow to copy `ttl.sh/stuttgart-things-sthings-backstage:<sha>` to `ghcr.io/stuttgart-things/sthings-backstage:<tag>` on demand.
- Imports the new reusable template `stuttgart-things/github-workflow-templates/.github/workflows/call-stage-image.yaml@main`.
- Inputs: `sha` (defaults to current ref), `tag` (default `stage`), `platform` (default `linux/amd64`).

## Test plan
- [ ] Run via Actions UI with defaults after a main push and verify `ghcr.io/stuttgart-things/sthings-backstage:stage` is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)