### PR TITLE
fix(stage-image): accept full image ref in sha input

### DIFF
--- a/.github/workflows/stage-image.yaml
+++ b/.github/workflows/stage-image.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: "Source commit SHA present on ttl.sh (defaults to current ref SHA)"
+        description: "Bare commit SHA on ttl.sh, OR a full image reference (e.g. ttl.sh/foo:abc). Defaults to current ref SHA."
         required: false
         type: string
       tag:
@@ -36,11 +36,16 @@ jobs:
     steps:
       - id: vars
         run: |
-          SHA="${{ inputs.sha }}"
-          if [ -z "$SHA" ]; then
-            SHA="${{ github.sha }}"
+          INPUT="${{ inputs.sha }}"
+          if [ -z "$INPUT" ]; then
+            INPUT="${{ github.sha }}"
           fi
-          echo "source-image=ttl.sh/stuttgart-things-sthings-backstage:${SHA}" >> $GITHUB_OUTPUT
+          if [[ "$INPUT" == *"/"* ]]; then
+            SOURCE="$INPUT"
+          else
+            SOURCE="ttl.sh/stuttgart-things-sthings-backstage:${INPUT}"
+          fi
+          echo "source-image=${SOURCE}" >> $GITHUB_OUTPUT
           echo "target-image=ghcr.io/stuttgart-things/sthings-backstage:${{ inputs.tag }}" >> $GITHUB_OUTPUT
 
   stage:


### PR DESCRIPTION
## Summary
- Run [24445356258](https://github.com/stuttgart-things/sthings-backstage/actions/runs/24445356258) failed because the `sha` input was dispatched with a full image reference, and the resolve step unconditionally prepended `ttl.sh/stuttgart-things-sthings-backstage:`, producing a doubled ref: `ttl.sh/stuttgart-things-sthings-backstage:ttl.sh/stuttgart-things-sthings-backstage:3010f6d...`.
- The resolve step now detects a `/` in the input and passes it through verbatim; bare SHAs still get the registry/name prepended.
- Input description updated.

## Test plan
- [ ] Dispatch with a bare SHA — verify the `ttl.sh/…` prefix is added.
- [ ] Dispatch with a full `ttl.sh/…:<sha>` reference — verify it's passed through unchanged and the copy succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)