### PR TITLE
fix(stage-image): drop sha input, always use github.sha

### DIFF
--- a/.github/workflows/stage-image.yaml
+++ b/.github/workflows/stage-image.yaml
@@ -3,10 +3,6 @@ name: Stage Image (ttl.sh -> ghcr.io)
 on:
   workflow_dispatch:
     inputs:
-      sha:
-        description: "Bare commit SHA on ttl.sh, OR a full image reference (e.g. ttl.sh/foo:abc). Defaults to current ref SHA."
-        required: false
-        type: string
       tag:
         description: "Target tag on ghcr.io"
         required: false
@@ -27,32 +23,10 @@ permissions:
   packages: write
 
 jobs:
-  resolve:
-    name: Resolve inputs
-    runs-on: ubuntu-latest
-    outputs:
-      source-image: ${{ steps.vars.outputs.source-image }}
-      target-image: ${{ steps.vars.outputs.target-image }}
-    steps:
-      - id: vars
-        run: |
-          INPUT="${{ inputs.sha }}"
-          if [ -z "$INPUT" ]; then
-            INPUT="${{ github.sha }}"
-          fi
-          if [[ "$INPUT" == *"/"* ]]; then
-            SOURCE="$INPUT"
-          else
-            SOURCE="ttl.sh/stuttgart-things-sthings-backstage:${INPUT}"
-          fi
-          echo "source-image=${SOURCE}" >> $GITHUB_OUTPUT
-          echo "target-image=ghcr.io/stuttgart-things/sthings-backstage:${{ inputs.tag }}" >> $GITHUB_OUTPUT
-
   stage:
-    needs: resolve
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-stage-image.yaml@main
     with:
-      source-image: ${{ needs.resolve.outputs.source-image }}
-      target-image: ${{ needs.resolve.outputs.target-image }}
+      source-image: ttl.sh/stuttgart-things-sthings-backstage:${{ github.sha }}
+      target-image: ghcr.io/stuttgart-things/sthings-backstage:${{ inputs.tag }}
       target-registry: ghcr.io
       platform: ${{ inputs.platform }}


### PR DESCRIPTION
## Summary
- Removes the free-text `sha` input. Users re-dispatching the workflow were pasting the previously-mangled string back in, reproducing the doubled-reference failure.
- `source-image` is now built directly from `github.sha`, which matches the commit of the ref picked in the Actions dispatch UI.
- `tag` and `platform` inputs kept.

## Test plan
- [ ] Dispatch from the Actions UI on `main` and verify `ghcr.io/stuttgart-things/sthings-backstage:stage` is published with the HEAD commit's image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)