### PR TITLE
feat(auth): add opt-in OIDC (Zitadel) sign-in alongside GitHub

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -1,6 +1,12 @@
 app:
   title: ${APP_TITLE:-sthings}
   baseUrl: ${APP_BASE_URL}
+  # Frontend-visible auth feature flags. `oidcEnabled` controls whether the
+  # SignInPage shows the Zitadel/OIDC button (the corresponding backend module
+  # is also gated by AUTH_OIDC_ENABLED in packages/backend/src/index.ts).
+  # GitHub stays always-on so existing flows are unaffected.
+  auth:
+    oidcEnabled: ${AUTH_OIDC_ENABLED:-false}
 
 organization:
   name: ${ORGANIZATION_NAME:-sthings}
@@ -100,6 +106,23 @@ auth:
         # enterpriseInstanceUrl: ${GHE_URL}
         signIn:
           resolvers:
+            - resolver: usernameMatchingUserEntityName
+    # OIDC provider (Zitadel). Block is always present so substitution works
+    # everywhere; the backend module is only loaded when AUTH_OIDC_ENABLED=true
+    # (see packages/backend/src/index.ts), so unset env vars don't blow up
+    # GitHub-only environments. Provisioned by the zitadel-config Terraform
+    # module on stuttgart-things.
+    oidc:
+      development:
+        metadataUrl: ${ZITADEL_ISSUER:-}
+        clientId: ${ZITADEL_CLIENT_ID:-}
+        clientSecret: ${ZITADEL_CLIENT_SECRET:-}
+        prompt: auto
+        signIn:
+          resolvers:
+            # Match on email first (works for federated users with no GitHub
+            # entity), fall back to username for legacy entities.
+            - resolver: emailMatchingUserEntityProfileEmail
             - resolver: usernameMatchingUserEntityName
 
 scaffolder:

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -37,8 +37,10 @@ import {
     AlertDisplay,
     OAuthRequestDialog,
     SignInPage,
+    SignInProviderConfig,
 } from '@backstage/core-components';
-import { githubAuthApiRef } from '@backstage/core-plugin-api';
+import { githubAuthApiRef, useApi, configApiRef } from '@backstage/core-plugin-api';
+import { oidcAuthApiRef } from './apis';
 import { UnifiedThemeProvider } from '@backstage/theme';
 import LightIcon from '@material-ui/icons/WbSunny';
 import DarkIcon from '@material-ui/icons/Brightness2';
@@ -101,21 +103,36 @@ const app = createApp({
     });
   },
   components: {
-    SignInPage: props => (
-      <SignInPage
-        {...props}
-        auto
-        providers={[
-          'guest',
-          {
-            id: 'github-auth-provider',
-            title: 'GitHub',
-            message: 'Sign in using GitHub',
-            apiRef: githubAuthApiRef,
-          },
-        ]}
-      />
-    ),
+    // Config-driven SignInPage: GitHub stays always-on; OIDC (Zitadel) is
+    // appended only when `app.auth.oidcEnabled=true` in app-config. The
+    // backend-side OIDC module is gated by AUTH_OIDC_ENABLED — both flags
+    // are driven by the same env var via Flux substitution. GitHub-only
+    // environments see exactly the same SignInPage as before.
+    SignInPage: props => {
+      const configApi = useApi(configApiRef);
+      const oidcEnabled =
+        configApi.getOptionalBoolean('app.auth.oidcEnabled') ?? false;
+      const providers: Array<'guest' | SignInProviderConfig> = [
+        'guest',
+        {
+          id: 'github-auth-provider',
+          title: 'GitHub',
+          message: 'Sign in using GitHub',
+          apiRef: githubAuthApiRef,
+        },
+        ...(oidcEnabled
+          ? [
+              {
+                id: 'oidc-auth-provider',
+                title: 'Zitadel',
+                message: 'Sign in using Zitadel SSO',
+                apiRef: oidcAuthApiRef,
+              },
+            ]
+          : []),
+      ];
+      return <SignInPage {...props} auto providers={providers} />;
+    },
   },
 });
 

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -7,7 +7,27 @@ import {
   AnyApiFactory,
   configApiRef,
   createApiFactory,
+  createApiRef,
+  discoveryApiRef,
+  oauthRequestApiRef,
+  OAuthApi,
+  ProfileInfoApi,
+  BackstageIdentityApi,
+  SessionApi,
 } from '@backstage/core-plugin-api';
+import { OAuth2 } from '@backstage/core-app-api';
+
+// Generic OIDC auth API — used to talk to any OIDC IdP configured under
+// auth.providers.oidc in app-config (today: Zitadel for the PR-preview auth
+// spike, sthings-backstage#82). The factory below is registered
+// unconditionally, but only takes effect when the backend module is loaded
+// (AUTH_OIDC_ENABLED=true) and the SignInPage offers it as a choice
+// (app.auth.oidcEnabled=true).
+export const oidcAuthApiRef = createApiRef<
+  OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
+>({
+  id: 'auth.oidc',
+});
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -16,4 +36,25 @@ export const apis: AnyApiFactory[] = [
     factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
   }),
   ScmAuth.createDefaultApiFactory(),
+  createApiFactory({
+    api: oidcAuthApiRef,
+    deps: {
+      configApi: configApiRef,
+      discoveryApi: discoveryApiRef,
+      oauthRequestApi: oauthRequestApiRef,
+    },
+    factory: ({ configApi, discoveryApi, oauthRequestApi }) =>
+      OAuth2.create({
+        configApi,
+        discoveryApi,
+        oauthRequestApi,
+        provider: {
+          id: 'oidc',
+          title: 'OIDC',
+          icon: () => null,
+        },
+        environment: configApi.getOptionalString('auth.environment') ?? 'development',
+        defaultScopes: ['openid', 'profile', 'email'],
+      }),
+  }),
 ];

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,6 +23,7 @@
     "@backstage/plugin-auth-backend": "^0.29.0",
     "@backstage/plugin-auth-backend-module-github-provider": "^0.5.1",
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.2.17",
+    "@backstage/plugin-auth-backend-module-oidc-provider": "^0.4.16",
     "@backstage/plugin-auth-node": "^0.7.0",
     "@backstage/plugin-catalog-backend": "^3.5.0",
     "@backstage/plugin-catalog-backend-module-logs": "^0.1.20",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -40,6 +40,12 @@ backend.add(import('@backstage/plugin-auth-backend'));
 // See https://backstage.io/docs/backend-system/building-backends/migrating#the-auth-plugin
 backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
 backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
+// OIDC (Zitadel) provider — opt-in via AUTH_OIDC_ENABLED=true to keep
+// GitHub-only environments fully unchanged. When enabled, the provider
+// reads auth.providers.oidc.development from app-config (sthings-backstage#82).
+if (process.env.AUTH_OIDC_ENABLED === 'true') {
+  backend.add(import('@backstage/plugin-auth-backend-module-oidc-provider'));
+}
 // See https://backstage.io/docs/auth/guest/provider
 
 // catalog plugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,6 +3603,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-backend-module-oidc-provider@npm:^0.4.16":
+  version: 0.4.16
+  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.16"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/plugin-auth-backend": "npm:^0.29.0"
+    "@backstage/plugin-auth-node": "npm:^0.7.1"
+    "@backstage/types": "npm:^1.2.2"
+    express: "npm:^4.22.0"
+    openid-client: "npm:^5.5.0"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10c0/ed87e3d5907e46af84ed28edea50ea6ae6b689b6b12ad6c6585d82d963d4ed3ab80a8973018f4f1a4993668c30443756c5d85a7b9cab564412a18f169ce72fda
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-backend@npm:^0.29.0":
   version: 0.29.0
   resolution: "@backstage/plugin-auth-backend@npm:0.29.0"
@@ -16972,6 +16989,7 @@ __metadata:
     "@backstage/plugin-auth-backend": "npm:^0.29.0"
     "@backstage/plugin-auth-backend-module-github-provider": "npm:^0.5.1"
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.17"
+    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:^0.4.16"
     "@backstage/plugin-auth-node": "npm:^0.7.0"
     "@backstage/plugin-catalog-backend": "npm:^3.5.0"
     "@backstage/plugin-catalog-backend-module-logs": "npm:^0.1.20"
@@ -24606,6 +24624,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^4.15.9":
+  version: 4.15.9
+  resolution: "jose@npm:4.15.9"
+  checksum: 10c0/4ed4ddf4a029db04bd167f2215f65d7245e4dc5f36d7ac3c0126aab38d66309a9e692f52df88975d99429e357e5fd8bab340ff20baab544d17684dd1d940a0f4
+  languageName: node
+  linkType: hard
+
 "jose@npm:^5.0.0":
   version: 5.10.0
   resolution: "jose@npm:5.10.0"
@@ -25674,6 +25699,15 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "lru-cache@npm:6.0.0"
+  dependencies:
+    yallist: "npm:^4.0.0"
+  checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
   languageName: node
   linkType: hard
 
@@ -27417,6 +27451,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-hash@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "object-hash@npm:2.2.0"
+  checksum: 10c0/1527de843926c5442ed61f8bdddfc7dc181b6497f725b0e89fcf50a55d9c803088763ed447cac85a5aa65345f1e99c2469ba679a54349ef3c4c0aeaa396a3eb9
+  languageName: node
+  linkType: hard
+
 "object-hash@npm:^3.0.0":
   version: 3.0.0
   resolution: "object-hash@npm:3.0.0"
@@ -27541,6 +27582,13 @@ __metadata:
     "@octokit/types": "npm:^13.0.0"
     "@octokit/webhooks": "npm:^12.3.1"
   checksum: 10c0/12287dc20f951854117eace8d983b14b03f77cf515bf4da642e64bf2dba7e5fd60f08eb37e4a2d3f6dc3c910c2a607e62b619f0ebd3f59bf67b4daa8915f0e34
+  languageName: node
+  linkType: hard
+
+"oidc-token-hash@npm:^5.0.3":
+  version: 5.2.0
+  resolution: "oidc-token-hash@npm:5.2.0"
+  checksum: 10c0/4fa9a6f0a27c0b304aa2e4a37e433e871fb2e71418b62ada7305022ed7c70a4b325a81a4ee9661bf0c456cda0acdbeb564e68659bd6fe6a192b20bdec11688ea
   languageName: node
   linkType: hard
 
@@ -27674,6 +27722,18 @@ __metadata:
   dependencies:
     yaml: "npm:^2.2.1"
   checksum: 10c0/3b9a663bf71f9292880c970a80f6f1a8db0ee475451c03b4fd336da957a24372349594d7868ce0a60b3a0875844a1f0e906e8fec8ef4220c06aa70670bfa3148
+  languageName: node
+  linkType: hard
+
+"openid-client@npm:^5.5.0":
+  version: 5.7.1
+  resolution: "openid-client@npm:5.7.1"
+  dependencies:
+    jose: "npm:^4.15.9"
+    lru-cache: "npm:^6.0.0"
+    object-hash: "npm:^2.2.0"
+    oidc-token-hash: "npm:^5.0.3"
+  checksum: 10c0/6aae649758562002eace7574b6eda02be7eddbb0df61eef497ae98b7a4a0ae4c6b09f3f0c1b9b6cb7fcc0c70bbde2576691bf31b870db1f19ab634c1def10bc7
   languageName: node
   linkType: hard
 
@@ -34817,7 +34877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yallist@npm:4.0.0":
+"yallist@npm:4.0.0, yallist@npm:^4.0.0":
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a


### PR DESCRIPTION
## Summary
Part 2 of #82. Makes the Backstage auth provider configurable so we can A/B Zitadel/OIDC strategies without breaking the existing GitHub sign-in.

**Non-breaking by design:**
- GitHub stays the unconditional default
- OIDC backend module is only loaded when `AUTH_OIDC_ENABLED=true` (env var) → unset `ZITADEL_*` vars cannot crash a GitHub-only environment
- SignInPage button only appears when `app.auth.oidcEnabled=true` (frontend-visible config flag driven by the same env var)
- All three Zitadel env vars have empty-string defaults in substitution so config evaluation never fails

## What's changed

### Backend
- `packages/backend/package.json` — adds `@backstage/plugin-auth-backend-module-oidc-provider@^0.4.16`
- `packages/backend/src/index.ts` — registers the OIDC module behind `AUTH_OIDC_ENABLED===true`

### Config
- `app-config.yaml`:
  - new `app.auth.oidcEnabled` flag (frontend-visible)
  - new `auth.providers.oidc.development` block reading `ZITADEL_ISSUER` / `ZITADEL_CLIENT_ID` / `ZITADEL_CLIENT_SECRET`
  - sign-in resolvers prefer `emailMatchingUserEntityProfileEmail`, fall back to `usernameMatchingUserEntityName`

### Frontend
- `packages/app/src/apis.ts` — new `oidcAuthApiRef` + `OAuth2.create` factory (provider id `oidc`, scopes `openid profile email`)
- `packages/app/src/App.tsx` — `SignInPage` is now a function component that reads `app.auth.oidcEnabled` from `configApi` and conditionally appends the Zitadel button to `providers={[guest, github, ...maybe(zitadel)]}`

## Activate on a deployment
```bash
export AUTH_OIDC_ENABLED=true
export ZITADEL_ISSUER=https://zitadel.homerun2-dev.sthings-vsphere.labul.sva.de
export ZITADEL_CLIENT_ID=<from terraform output>
export ZITADEL_CLIENT_SECRET=<from terraform output>
```

For prod homerun2-dev the SOPS values land via stuttgart-things/stuttgart-things#2219; the corresponding Flux substitution wires them into the running pod.

## Test plan
- [x] `yarn tsc` passes
- [ ] Local dev with only GitHub vars set → SignInPage shows only guest + GitHub (regression check)
- [ ] Local dev with `AUTH_OIDC_ENABLED=true` + Zitadel vars set → Zitadel button appears, click flow redirects to Zitadel and back
- [ ] Sign-in resolver maps a Zitadel-issued identity to a catalog User entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)