### PR TITLE
fix(app): unblock dev on remote VM (rebuild:native, ToastApi bridge, randomUUID polyfill)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "backstage-cli repo start",
+    "rebuild:native": "bash scripts/rebuild-native.sh",
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build-image": "yarn workspace backend build-image",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,6 +21,7 @@
     "@backstage/core-app-api": "^1.19.6",
     "@backstage/core-components": "^0.18.8",
     "@backstage/core-plugin-api": "^1.12.4",
+    "@backstage/frontend-plugin-api": "^0.17.0",
     "@backstage/integration-react": "^1.2.16",
     "@backstage/plugin-api-docs": "^0.14.0",
     "@backstage/plugin-catalog": "^2.0.1",

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -5,6 +5,7 @@ import {
 } from '@backstage/integration-react';
 import {
   AnyApiFactory,
+  alertApiRef,
   configApiRef,
   createApiFactory,
   createApiRef,
@@ -15,6 +16,7 @@ import {
   BackstageIdentityApi,
   SessionApi,
 } from '@backstage/core-plugin-api';
+import { toastApiRef } from '@backstage/frontend-plugin-api';
 import { OAuth2 } from '@backstage/core-app-api';
 
 // Generic OIDC auth API — used to talk to any OIDC IdP configured under
@@ -36,6 +38,39 @@ export const apis: AnyApiFactory[] = [
     factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
   }),
   ScmAuth.createDefaultApiFactory(),
+  // Bridge the new-frontend-system ToastApi (core.toast) onto the legacy
+  // AlertApi so plugins built against the new frontend system work in this
+  // legacy createApp() runtime. @backstage/plugin-notifications'
+  // NotificationsSidebarItem calls useApi(toastApiRef), which is otherwise
+  // unbound here and throws NotImplementedError. The legacy app already
+  // renders AlertDisplay, so forwarded toasts surface in the standard
+  // snackbar. Mapping follows the AlertMessage deprecation guide.
+  createApiFactory({
+    api: toastApiRef,
+    deps: { alertApi: alertApiRef },
+    factory: ({ alertApi }) => ({
+      post(toast) {
+        const severity = (
+          {
+            neutral: 'info',
+            info: 'info',
+            success: 'success',
+            warning: 'warning',
+            danger: 'error',
+          } as const
+        )[toast.status ?? 'success'];
+        const message = [toast.title, toast.description]
+          .filter(part => typeof part === 'string' && part.length > 0)
+          .join(' — ');
+        alertApi.post({
+          message: message || 'Notification',
+          severity,
+          display: toast.timeout ? 'transient' : 'permanent',
+        });
+        return { close() {} };
+      },
+    }),
+  }),
   createApiFactory({
     api: oidcAuthApiRef,
     deps: {

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -3,4 +3,18 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import '@backstage/ui/css/styles.css';
 
+// crypto.randomUUID() is only exposed in secure contexts (HTTPS or localhost).
+// When the dev app is served over plain HTTP to a hostname (e.g.
+// http://dev-vm3...:3000) it is undefined, and @backstage/plugin-signals'
+// SignalClient.subscribe throws. Provide a guarded fallback so dev-on-VM works.
+if (typeof globalThis.crypto?.randomUUID !== 'function') {
+  const cryptoObj = (globalThis.crypto ??= {} as Crypto);
+  cryptoObj.randomUUID = () =>
+    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, char => {
+      const rand = (Math.random() * 16) | 0;
+      const value = char === 'x' ? rand : (rand & 0x3) | 0x8;
+      return value.toString(16);
+    }) as `${string}-${string}-${string}-${string}-${string}`;
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/scripts/rebuild-native.sh
+++ b/scripts/rebuild-native.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Rebuild native modules that yarn skips because `enableScripts` is false.
+#
+# Currently this only affects `better-sqlite3`: its prebuilt binary is fetched
+# by a postinstall script (`prebuild-install`), so when build scripts are
+# disabled `yarn install` leaves only source and the backend crashes at startup
+# with "Could not locate the bindings file" (core.auth -> core.httpRouter),
+# taking down the kubernetes / notifications / signals plugins.
+#
+# Run this once after every `yarn install`:  yarn rebuild:native
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG="$ROOT/node_modules/better-sqlite3"
+
+if [[ ! -d "$PKG" ]]; then
+  echo "error: $PKG not found — run 'yarn install' first." >&2
+  exit 1
+fi
+
+# 1. Locate node-gyp. The system one (/usr/bin/node-gyp) can have a broken
+#    Python gyp module, so prefer the copy bundled inside the active npm.
+NPM_ROOT="$(npm root -g 2>/dev/null || true)"
+NODE_GYP="$NPM_ROOT/npm/node_modules/node-gyp/bin/node-gyp.js"
+if [[ -f "$NODE_GYP" ]]; then
+  GYP_CMD=(node "$NODE_GYP")
+elif command -v node-gyp >/dev/null 2>&1; then
+  echo "warning: falling back to PATH node-gyp ($(command -v node-gyp))" >&2
+  GYP_CMD=(node-gyp)
+else
+  echo "error: no node-gyp found (looked in npm root and PATH)." >&2
+  exit 1
+fi
+
+# 2. better-sqlite3's gyp pins g++-11 / gcc-11 by name. If those aren't present,
+#    shim them to whatever modern gcc/g++ is installed (>= 11 supports C++20).
+SHIM_DIR=""
+if ! command -v g++-11 >/dev/null 2>&1; then
+  CXX_REAL=""
+  CC_REAL=""
+  for v in 14 13 12 11; do
+    if command -v "g++-$v" >/dev/null 2>&1; then
+      CXX_REAL="$(command -v "g++-$v")"
+      CC_REAL="$(command -v "gcc-$v" || command -v "g++-$v")"
+      break
+    fi
+  done
+  # Fall back to the unversioned compilers if no g++-NN was found.
+  [[ -z "$CXX_REAL" ]] && CXX_REAL="$(command -v g++ || true)"
+  [[ -z "$CC_REAL"  ]] && CC_REAL="$(command -v gcc || true)"
+  if [[ -z "$CXX_REAL" ]]; then
+    echo "error: no C++ compiler found to shim as g++-11." >&2
+    exit 1
+  fi
+  SHIM_DIR="$(mktemp -d)"
+  ln -sf "$CXX_REAL" "$SHIM_DIR/g++-11"
+  ln -sf "$CC_REAL"  "$SHIM_DIR/gcc-11"
+  ln -sf "$CC_REAL"  "$SHIM_DIR/cc-11"
+  export PATH="$SHIM_DIR:$PATH"
+  echo "shimmed g++-11 -> $CXX_REAL"
+fi
+trap '[[ -n "$SHIM_DIR" ]] && rm -rf "$SHIM_DIR"' EXIT
+
+echo "building better-sqlite3 (node $(node --version), ABI $(node -p process.versions.modules))..."
+"${GYP_CMD[@]}" rebuild -C "$PKG"
+
+# 3. Verify the addon actually loads.
+node -e "const D=require('better-sqlite3');const d=new D(':memory:');d.prepare('select 1').get();d.close();console.log('ok: better-sqlite3 '+require('better-sqlite3/package.json').version+' loads under node '+process.version)"


### PR DESCRIPTION
Three changes that unblock running the Backstage app in dev on a remote VM accessed over plain HTTP.

## 1. `chore(dev)`: add `rebuild:native` script for better-sqlite3 binding

### Problem
Local `yarn install` runs with `enableScripts` disabled, so `better-sqlite3`'s postinstall (`prebuild-install`) is skipped and **no native binding** is produced. The backend then crashes at startup:

```
Could not locate the bindings file ... better_sqlite3.node
Failed to instantiate service 'core.auth' for 'kubernetes'/'notifications'/'signals'
```

taking down the `kubernetes`, `notifications`, and `signals` plugins. (`isolated-vm` is unaffected — its prebuilds ship in the npm tarball.)

### Change
- Add **`scripts/rebuild-native.sh`** and a **`yarn rebuild:native`** script.
- Portable: locates npm's bundled `node-gyp`, shims the pinned `g++-11` to an available modern `g++`, builds the addon, and verifies it loads.
- Run once after each `yarn install`. Targets Node 22 (ABI 127); re-run under Node 24 if the dev Node is bumped.

## 2. `fix(app)`: bridge new-frontend ToastApi onto legacy AlertApi

`NotificationsSidebarItem` from `@backstage/plugin-notifications` calls `useApi(toastApiRef)`, which is unbound in this legacy `createApp()` runtime and throws `NotImplementedError`. Forwards `toast.post()` to the existing `AlertApi` so notifications surface in the standard `AlertDisplay` snackbar.

## 3. `fix(app)`: polyfill crypto.randomUUID for insecure-context dev

`crypto.randomUUID()` is only exposed in secure contexts (HTTPS or localhost). Served over plain HTTP to a hostname (`http://dev-vm3...:3000`), it is `undefined` and `@backstage/plugin-signals`' `SignalClient.subscribe` throws a `TypeError`. Adds a guarded fallback that is a no-op in real secure contexts (production HTTPS, localhost).

## Test plan
- `task dev` on the dev VM, browse over `http://dev-vm3...:3000` — backend starts with all plugins, app loads, signals subscription no longer throws, notifications render in the snackbar.

## Notes / follow-up
A more permanent alternative to (1) is setting `enableScripts: true` in `.yarnrc.yml` so `yarn install` fetches the prebuilt binary automatically — left out here since it affects CI and teammates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)