### PR TITLE
fix(ci): pass real username to ghcr crane copy (fixes promote DENIED)

### DIFF
--- a/.github/workflows/crane-tag.yaml
+++ b/.github/workflows/crane-tag.yaml
@@ -47,11 +47,13 @@ jobs:
             --source ttl.sh/stuttgart-things-sthings-backstage:${{ steps.vars.outputs.sha }}
             --target ghcr.io/stuttgart-things/sthings-backstage:${{ steps.vars.outputs.release_tag }}
             --target-registry ghcr.io
-            --target-username env:REGISTRY_USERNAME
+            --target-username ${{ github.actor }}
             --target-password env:REGISTRY_PASSWORD
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
-          REGISTRY_USERNAME: ${{ github.actor }}
+          # ghcr validates the basic-auth username, so it must be a real
+          # account (passed inline via --target-username), not an env: ref —
+          # the crane module only resolves env: for the password Secret.
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,11 +100,13 @@ jobs:
             --source ttl.sh/stuttgart-things-sthings-backstage:${{ env.SOURCE_SHA }}
             --target ghcr.io/stuttgart-things/sthings-backstage:v${{ env.VERSION }}
             --target-registry ghcr.io
-            --target-username env:REGISTRY_USERNAME
+            --target-username ${{ github.actor }}
             --target-password env:REGISTRY_PASSWORD
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
-          REGISTRY_USERNAME: ${{ github.actor }}
+          # ghcr validates the basic-auth username, so it must be a real
+          # account (passed inline via --target-username), not an env: ref —
+          # the crane module only resolves env: for the password Secret.
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Copy ttl.sh image to ghcr.io latest
@@ -117,11 +119,13 @@ jobs:
             --source ttl.sh/stuttgart-things-sthings-backstage:${{ env.SOURCE_SHA }}
             --target ghcr.io/stuttgart-things/sthings-backstage:latest
             --target-registry ghcr.io
-            --target-username env:REGISTRY_USERNAME
+            --target-username ${{ github.actor }}
             --target-password env:REGISTRY_PASSWORD
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         env:
-          REGISTRY_USERNAME: ${{ github.actor }}
+          # ghcr validates the basic-auth username, so it must be a real
+          # account (passed inline via --target-username), not an env: ref —
+          # the crane module only resolves env: for the password Secret.
           REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary


### PR DESCRIPTION
## Problem

The `promote-image` job (added in #99) ran on the v1.4.2 release but failed pushing to ghcr:

```
crane copy ... ghcr.io/stuttgart-things/sthings-backstage:v1.4.2
Error: GET https://ghcr.io/token?scope=repository:stuttgart-things/sthings-backstage:push,pull&service=ghcr.io: DENIED: denied
```

Root cause: the step passed `--target-username env:REGISTRY_USERNAME`. The `stuttgart-things/dagger/crane` module only resolves the `env:` prefix for the **password** (it's typed as a Dagger `Secret`); the **username** is forwarded verbatim. So ghcr received the literal username `env:REGISTRY_USERNAME`, and ghcr **validates the basic-auth username** → its bearer-token request was denied.

## Verification

```
$ skopeo login ghcr.io -u "env:REGISTRY_USERNAME" --password <token>
FATAL ... 403 Forbidden
$ skopeo login ghcr.io -u patrick-hermann-sva --password <token>
Login Succeeded!
```

Same token — only the username differs. Confirms ghcr rejects the bogus username.

## Fix

Pass `--target-username ${{ github.actor }}` inline (a real account) and drop the now-unused `REGISTRY_USERNAME` env var, in both:
- `release.yaml` (`promote-image`, both copy steps)
- `crane-tag.yaml` (same latent bug — its only prior run also failed)

The password stays as `env:REGISTRY_PASSWORD` = `GITHUB_TOKEN` (the module resolves that correctly). With `permissions: packages: write` and the package already linked to this repo, the push will be authorized.

## Note

`v1.4.2` + `latest` have been promoted to ghcr manually in the meantime (skopeo, from the still-live ttl.sh build), so the release is deployable now. This PR makes the **next** release promote automatically without manual help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)