### PR TITLE
fix(backend): compile better-sqlite3 native binding in image

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -53,6 +53,15 @@ RUN tar xzf skeleton.tar.gz && rm skeleton.tar.gz
 RUN --mount=type=cache,target=/home/node/.cache/yarn,sharing=locked,uid=1000,gid=1000 \
     yarn workspaces focus --all --production && rm -rf "$(yarn cache clean)"
 
+# better-sqlite3's prebuilt binary isn't fetched under this install, so the
+# install leaves only source and the backend crashes at startup with "Could
+# not locate the bindings file" (core.auth -> core.httpRouter) whenever
+# backend.database uses better-sqlite3 (e.g. the labul cluster's :memory: db).
+# Compile the native binding from source here, where the toolchain exists;
+# the runtime stage then inherits the built .node via COPY --from=builder.
+COPY --chown=node:node scripts/rebuild-native.sh ./scripts/rebuild-native.sh
+RUN bash scripts/rebuild-native.sh
+
 # ---------- Stage 2: runtime (no build toolchain) ----------
 FROM node:24-bookworm-slim
 


### PR DESCRIPTION
## Problem

v1.4.x images ship better-sqlite3 **without its native binding** — the install doesn't fetch the prebuilt binary and build scripts don't compile it, leaving only source. When `backend.database.client: better-sqlite3` is used (e.g. the labul platform-sthings cluster's `:memory:` db), the backend crashes on startup:

```
Plugin 'app' threw an error during startup ...
Failed to instantiate service 'core.auth' ... 
Error: Could not locate the bindings file ... better_sqlite3.node
```

Found by deploying v1.4.3 to labul — the pod never reached Ready (the older `07eedb` image has a working binding, which is why it ran). Pre-existing in v1.4.0–v1.4.3, not caused by the multi-stage change.

## Fix

Run the repo's existing `scripts/rebuild-native.sh` in the **builder** stage (which has g++/python/node-gyp), compiling the binding from source. The runtime stage inherits the built `.node` via `COPY --from=builder`. The script also shims the `g++-11` name that better-sqlite3's gyp pins.

## Verified

Built the image via Dagger and ran in a container:
```
better-sqlite3 OK rows=1
isolated-vm OK
```

So the next release will start cleanly on SQLite clusters. After it publishes (v1.4.4), the labul `imageTag` can be bumped from `07eedb` to `v1.4.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)