### PR TITLE
fix(backend): restore mkdocs in runtime image for local techdocs

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -69,6 +69,21 @@ FROM node:24-bookworm-slim
 ENV NODE_OPTIONS="--no-node-snapshot"
 ENV NODE_ENV=production
 
+# TechDocs is configured with generator.runIn: 'local' in this deployment, so
+# the backend spawns `mkdocs` in-process. It must be present at runtime, or doc
+# builds fail with "spawn mkdocs ENOENT". (Only mkdocs + python here — the C/C++
+# build toolchain stays out of the runtime image.)
+# hadolint ignore=DL3013,DL3042
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    python3 -m pip install --break-system-packages --no-cache-dir \
+      mkdocs \
+      mkdocs-material \
+      mkdocs-techdocs-core
+
 USER node
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

After the multi-stage hardening (#100), TechDocs builds fail:

```
Failed to generate docs ... caused by Error: spawn mkdocs ENOENT
```

The hardening dropped `mkdocs`/`python` from the runtime stage assuming `techdocs.generator.runIn: 'docker'` (the repo's baked app-config). But the **labul deployment's app-config overrides this to `runIn: 'local'`**, so the backend spawns `mkdocs` in-process — which is no longer in the image.

## Fix

Reinstall `python3` + `mkdocs` (`mkdocs-material`, `mkdocs-techdocs-core`) in the **runtime** stage only. The C/C++ build toolchain stays out of the runtime image, so the main CVE reduction (the 136-CVE `linux-libc-dev` + compilers) is preserved.

## Verified (built image)

```
mkdocs, version 1.6.1
better-sqlite3 OK
isolated-vm OK
```

CVE trade-off: re-adding python lands the image ~160 HIGH/CRITICAL (vs 135 without mkdocs, vs 284 original) — still a large reduction, and TechDocs works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)