### PR TITLE
chore(renovate): defer major updates for backstage, react, isolated-vm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,41 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Defer Backstage major upgrades — done as dedicated, tested rollouts (deploy + verify on labul), not auto PRs",
+      "matchPackageNames": [
+        "@backstage/**",
+        "@backstage-community/**"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Stay on React 18 for Backstage compatibility — defer the React 19 major",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Defer isolated-vm major — native module (scaffolder), needs image build + scaffolder verification",
+      "matchPackageNames": [
+        "isolated-vm"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Stops Renovate from re-creating the deferred major-update PRs (closing them just made it reopen — #84 → #105). Disables **major** updates for `@backstage/**`, `@backstage-community/**`, `react`/`react-dom`, and `isolated-vm`; minor/patch updates continue normally.

These majors are intended to be done as dedicated, tested rollouts (image build + labul deploy-verify), not unattended PRs. Validated with `renovate-config-validator` (Config validated successfully).

Alternative if you'd rather keep them *visible-but-parked*: switch `enabled: false` → `dependencyDashboardApproval: true` so they show on the Dependency Dashboard and can be triggered with a checkbox. Happy to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)