### PR TITLE
feat(scaffolder): custom template card with prominent CTA and readable header

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -29,6 +29,7 @@ import {
     ClaimMachineryPickerFieldExtension,
     ClaimMachineryMultiClaimFieldExtension,
     RegistryClaimPickerFieldExtension,
+    TemplateCard,
 } from './scaffolder';
 
 import { createApp } from '@backstage/app-defaults';
@@ -155,7 +156,14 @@ const routes = (
         <ReportIssue />
       </TechDocsAddons>
     </Route>
-    <Route path="/create" element={<ScaffolderPage />}>
+    <Route
+      path="/create"
+      element={
+        <ScaffolderPage
+          components={{ TemplateCardComponent: TemplateCard }}
+        />
+      }
+    >
       <ScaffolderFieldExtensions>
         <ClaimMachineryPickerFieldExtension />
         <ClaimMachineryParametersFieldExtension />

--- a/packages/app/src/scaffolder/TemplateCard.tsx
+++ b/packages/app/src/scaffolder/TemplateCard.tsx
@@ -1,0 +1,155 @@
+import { Entity, RELATION_OWNED_BY, parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import { ItemCardHeader, Link, LinkButton } from '@backstage/core-components';
+import {
+  EntityRefLinks,
+  FavoriteEntity,
+  getEntityRelations,
+} from '@backstage/plugin-catalog-react';
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import Box from '@material-ui/core/Box';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Chip from '@material-ui/core/Chip';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(theme => ({
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+  // Make the body fill available space so the CTA stays pinned to the bottom
+  // and every card in a row has its action button aligned.
+  actionArea: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
+  header: {
+    backgroundImage: ({ cardBackgroundImage }: any) => cardBackgroundImage,
+    color: ({ cardFontColor }: any) => cardFontColor,
+  },
+  content: {
+    flex: 1,
+  },
+  description: {
+    // Prioritise the gist: clamp long descriptions to a few lines.
+    display: '-webkit-box',
+    WebkitLineClamp: 3,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    color: theme.palette.text.secondary,
+  },
+  meta: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.5),
+    marginTop: theme.spacing(1.5),
+    color: theme.palette.text.secondary,
+    fontSize: '0.8rem',
+  },
+  tags: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5),
+    marginTop: theme.spacing(1.5),
+  },
+  actions: {
+    padding: theme.spacing(2),
+    paddingTop: 0,
+  },
+  chooseButton: {
+    fontWeight: 700,
+  },
+}));
+
+/**
+ * Custom scaffolder template card with a clickable body and a prominent
+ * "Choose template" call-to-action. Injected via the
+ * `components.TemplateCardComponent` prop of {@link ScaffolderPage}.
+ */
+export const TemplateCard = (props: { template: Entity }) => {
+  const { template } = props;
+  const type = (template.spec?.type as string | undefined) ?? 'other';
+
+  const templateRoute = useRouteRef(scaffolderPlugin.routes.selectedTemplate);
+  const { namespace, name } = parseEntityRef(stringifyEntityRef(template));
+  const href = templateRoute({ namespace, templateName: name });
+
+  const { getPageTheme } = useTheme() as any;
+  const themeForType = getPageTheme({ themeId: type });
+  const classes = useStyles({
+    cardBackgroundImage: themeForType.backgroundImage,
+    cardFontColor: themeForType.fontColor,
+  });
+
+  const ownedByRelations = getEntityRelations(template, RELATION_OWNED_BY);
+  const tags = template.metadata.tags ?? [];
+  const title = template.metadata.title ?? template.metadata.name;
+
+  return (
+    <Card className={classes.card}>
+      <CardActionArea
+        className={classes.actionArea}
+        component={Link}
+        to={href}
+        data-testid="template-card-action-area"
+      >
+        <ItemCardHeader
+          title={title}
+          subtitle={type}
+          classes={{ root: classes.header }}
+        />
+        <CardContent className={classes.content}>
+          {template.metadata.description && (
+            <Typography variant="body2" className={classes.description}>
+              {template.metadata.description}
+            </Typography>
+          )}
+
+          {ownedByRelations.length > 0 && (
+            <div className={classes.meta}>
+              <span>Owner:&nbsp;</span>
+              <EntityRefLinks
+                entityRefs={ownedByRelations}
+                defaultKind="Group"
+                onClick={e => e.stopPropagation()}
+              />
+            </div>
+          )}
+
+          {tags.length > 0 && (
+            <div className={classes.tags}>
+              {tags.map(tag => (
+                <Chip key={tag} label={tag} size="small" />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </CardActionArea>
+
+      <CardActions className={classes.actions}>
+        <Box width="100%" display="flex" justifyContent="space-between" alignItems="center">
+          <FavoriteEntity entity={template} style={{ padding: 4 }} />
+          <LinkButton
+            to={href}
+            color="primary"
+            variant="contained"
+            size="large"
+            fullWidth
+            className={classes.chooseButton}
+            style={{ marginLeft: 8 }}
+            data-testid="template-card-choose"
+          >
+            Choose template
+          </LinkButton>
+        </Box>
+      </CardActions>
+    </Card>
+  );
+};

--- a/packages/app/src/scaffolder/index.ts
+++ b/packages/app/src/scaffolder/index.ts
@@ -37,6 +37,9 @@ export const RegistryClaimPickerFieldExtension = scaffolderPlugin.provide(
   }),
 );
 
+// Custom template card (clickable body + prominent CTA)
+export { TemplateCard } from './TemplateCard';
+
 // Also export the raw components if needed
 export {
   ClaimMachineryPickerExtension,

--- a/packages/app/src/theme.ts
+++ b/packages/app/src/theme.ts
@@ -209,7 +209,6 @@ const commonOverrides = {
   BackstageHeader: {
     styleOverrides: {
       header: {
-        backgroundImage: 'none',
         boxShadow: '0 1px 3px 0 rgba(0,0,0,0.08)',
       },
       title: {


### PR DESCRIPTION
## Summary
Improves the Create/scaffolder page based on UX review feedback.

- **Custom template card** (`TemplateCard.tsx`, wired via `ScaffolderPage components={{ TemplateCardComponent }}`):
  - Clickable card body (`CardActionArea`) + full-width primary **"Choose template"** CTA so the main action no longer gets lost.
  - Long descriptions clamped to 3 lines; owner badge, tags and a favorite toggle for faster scanning.
  - Uses Backstage `LinkButton` for type-safe client-side navigation.
- **Readable page header** (`theme.ts`): removed `backgroundImage: 'none'` from the `BackstageHeader` override. That line stripped the gradient from *every* header, leaving white title text on a light background — the "Create a new component" title looked blank/disabled. Restoring the gradient makes it readable again.

## Test plan
- `yarn tsc` passes clean.
- Verify the `/create` page header renders the dark purple gradient with readable white text.
- Verify template cards show the prominent "Choose template" button and the whole card body is clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)