### PR TITLE
fix(claim-machinery): surface real branch-create error instead of masking it

### DIFF
--- a/packages/backend/src/plugins/scaffolder-claim-machinery/action-render-multiple.ts
+++ b/packages/backend/src/plugins/scaffolder-claim-machinery/action-render-multiple.ts
@@ -446,6 +446,24 @@ export const claimMachineryRenderMultipleAction = (options: { config: Config }) 
         });
 
         if (!createBranchRes.ok) {
+          const createErrText = await createBranchRes.text();
+
+          // Only fall back to updating the ref when it already exists (a reused
+          // branch name). Any other failure — 401/403 auth, 5xx, validation —
+          // is the real error and must be surfaced. Previously every failure
+          // fell through to the PATCH below, which then reported the misleading
+          // "Reference does not exist" for a branch that was never created,
+          // masking the true cause (e.g. a transient GitHub auth 401).
+          const refAlreadyExists =
+            createBranchRes.status === 422 &&
+            /already exists/i.test(createErrText);
+
+          if (!refAlreadyExists) {
+            throw new Error(
+              `Failed to create branch: ${createBranchRes.status} ${createErrText}`,
+            );
+          }
+
           const updateBranchRes = await fetch(
             `${apiBase}/git/refs/heads/${prBranch}`,
             {
@@ -459,7 +477,7 @@ export const claimMachineryRenderMultipleAction = (options: { config: Config }) 
           if (!updateBranchRes.ok) {
             const errText = await updateBranchRes.text();
             throw new Error(
-              `Failed to create/update branch: ${updateBranchRes.status} ${errText}`,
+              `Failed to update existing branch: ${updateBranchRes.status} ${errText}`,
             );
           }
         }


### PR DESCRIPTION
## Problem

`scaffolder-claim-machinery`'s `action-render-multiple.ts` creates the PR branch with `POST /git/refs`, then on **any** failure falls back to `PATCH /git/refs/heads/<branch>` and throws only the PATCH error. Since each run uses a unique `create-claims-${category}-${Date.now()}` branch, that branch never exists when the POST fails for a non-collision reason — so the PATCH returns **`422 Reference does not exist`**, masking the true cause.

Seen live during a GitHub *"Authentication issues related to API requests"* incident:
- One run surfaced the raw **`401 Requires authentication`** at create-commit.
- An earlier run (failing one step later, at create-branch) showed only the misleading **`Reference does not exist`** — same 401 underneath, hidden by the fallback.

## Fix

Only fall back to `PATCH` when the `POST` failed **specifically** with `422` + *"already exists"* (a genuinely reused branch name). Every other failure — 401/403 auth, 5xx, validation — is rethrown verbatim as `Failed to create branch: <status> <body>`. The collision path now throws `Failed to update existing branch: …` so the two cases are distinguishable.

15-line change, mirrors the file's existing `if (!res.ok) throw` pattern used by every other GitHub call in the action. No behavioural change on the happy path or on a real name collision.

## Not included (possible follow-up)

A bounded retry/backoff on transient write failures (5xx / secondary-rate-limit / flapping 401) would let runs self-heal through brief GitHub blips. Left out to keep this focused on legibility; happy to add if wanted.